### PR TITLE
Allow base64 encoded pull secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ resource "azureopenshift_redhatopenshift_cluster" "test" {
     subnet_id = var.worker_subnet_id
   }
 
+  cluster_profile {
+    pull_secret = filebase64(var.pull_secret_file)
+  }
+
   service_principal {
     client_id     = var.client_id
     client_secret = var.client_secret

--- a/helpers/aro/cluster_profile_helper.go
+++ b/helpers/aro/cluster_profile_helper.go
@@ -53,7 +53,7 @@ func (cpe *ClusterProfileHelper) Expand(input []interface{}) *redhatopenshift.Cl
 	return &redhatopenshift.ClusterProfile{
 		ResourceGroupID:      utils.String(resourceGroupId),
 		Domain:               utils.String(domain),
-		PullSecret:           utils.String(pullSecret),
+		PullSecret:           utils.String(utils.Base64DecodeIfEncoded(pullSecret)),
 		FipsValidatedModules: redhatopenshift.FipsValidatedModules(fipsValidatedModules),
 	}
 }

--- a/helpers/utils/base64.go
+++ b/helpers/utils/base64.go
@@ -18,3 +18,14 @@ func base64IsEncoded(data string) bool {
 	_, err := base64.StdEncoding.DecodeString(data)
 	return err == nil
 }
+
+// Base64DecodeIfEncoded decodes data if the input is base64 encoded using
+// base64.StdEncoding.EncodeToString. If the input is not base64 encoded,
+// return the original input unchanged.
+func Base64DecodeIfEncoded(data string) string {
+	if base64IsEncoded(data) {
+		decodedPullSecret, _ := base64.StdEncoding.DecodeString(data)
+		return string(decodedPullSecret)
+	}
+	return data
+}


### PR DESCRIPTION
pull secrets are complex json strings, trying to load them as strings to pass as a string is hard.  this lets you pass through a base64 encoded pull secret to make it easier on the human stuck between two systems.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>