### PR TITLE
Removing the information of “version” as a read-only variable 

### DIFF
--- a/docs/resources/redhatopenshift_cluster.md
+++ b/docs/resources/redhatopenshift_cluster.md
@@ -41,7 +41,7 @@ description: |-
 
 - `console_url` (String)
 - `id` (String) The ID of this resource.
-- `version` (String)
+
 
 <a id="nestedblock--master_profile"></a>
 ### Nested Schema for `master_profile`


### PR DESCRIPTION
It could confuse customers regarding the ability to use TF to set cluster version.