### PR TITLE
fix: remove china support

### DIFF
--- a/azureopenshift/auth/auth.go
+++ b/azureopenshift/auth/auth.go
@@ -17,7 +17,9 @@ const (
 
 	AzurePublicString       = "public"
 	AzureUSGovernmentString = "usgovernment"
-	AzureChinaString        = "china"
+
+	// TODO: remove China support for now until ARO supports it.
+	// AzureChinaString        = "china"
 )
 
 type Config struct {
@@ -89,8 +91,9 @@ func defaultAroCredentialConstructorErrorHandler(numberOfSuccessfulCredentials i
 
 func getCloud(config Config) cloud.Configuration {
 	switch config.Environment {
-	case AzureChinaString:
-		return cloud.AzureChina
+	// TODO: remove China support for now until ARO supports it.
+	// case AzureChinaString:
+	// 	return cloud.AzureChina
 	case AzureUSGovernmentString:
 		return cloud.AzureGovernment
 	default:

--- a/azureopenshift/provider.go
+++ b/azureopenshift/provider.go
@@ -44,11 +44,14 @@ func Provider() *schema.Provider {
 			},
 
 			"environment": {
-				Type:         schema.TypeString,
-				Required:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("ARM_ENVIRONMENT", "public"),
-				Description:  "The Cloud Environment which should be used. Possible values are public, usgovernment, and china. Defaults to public.",
-				ValidateFunc: validation.StringInSlice([]string{auth.AzurePublicString, auth.AzureUSGovernmentString, auth.AzureChinaString}, false),
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_ENVIRONMENT", "public"),
+				// TODO: remove China support for now until ARO supports it.
+				// Description:  "The Cloud Environment which should be used. Possible values are public, usgovernment, and china. Defaults to public.",
+				// ValidateFunc: validation.StringInSlice([]string{auth.AzurePublicString, auth.AzureUSGovernmentString, auth.AzureChinaString}, false),
+				Description:  "The Cloud Environment which should be used. Possible values are public and usgovernment. Defaults to public.",
+				ValidateFunc: validation.StringInSlice([]string{auth.AzurePublicString, auth.AzureUSGovernmentString}, false),
 			},
 		},
 


### PR DESCRIPTION
AzureChina is not a supported region for ARO just yet, so we should remove support until (if) it becomes available.  Leaving the AzureChina code commented so it can easily be reverted.