### PR TITLE
refactor: reduce duplicate function call and simplify aro credential method

### DIFF
--- a/azureopenshift/auth/auth.go
+++ b/azureopenshift/auth/auth.go
@@ -53,7 +53,7 @@ func NewDefaultAroCredential(config Config) (*DefaultAroCredential, error) {
 
 	chain, err := azidentity.NewChainedTokenCredential([]azcore.TokenCredential{clientSecretCred, cliCred}, nil)
 	if err != nil {
-		return nil, err
+		return cred, err
 	}
 
 	cred.chain = chain

--- a/azureopenshift/clients/client.go
+++ b/azureopenshift/clients/client.go
@@ -21,8 +21,7 @@ func NewClient(stopCtx context.Context, config auth.Config) (*Client, error) {
 		return nil, err
 	}
 
-	options := &armpolicy.ClientOptions{}
-	options.ClientOptions = auth.GetOptions(config)
+	options := &armpolicy.ClientOptions{ClientOptions: *cred.GetClientOptions()}
 
 	openshiftClustersClient, err := redhatopenshift.NewOpenShiftClustersClient(config.SubscriptionId, cred, options)
 	if err != nil {


### PR DESCRIPTION
One final refactor needed for ARM changes to allow multiple different cloud environments.