### PR TITLE
fix: remove hard-coded profile count

### DIFF
--- a/azureopenshift/parse/cluster.go
+++ b/azureopenshift/parse/cluster.go
@@ -79,7 +79,7 @@ func InternalClusterId(clusterName string, workerProfiles []*redhatopenshift.Wor
 		return nil, err
 	}
 	matches := rgx.FindStringSubmatch(*profile.Name)
-	if len(matches) != 3 {
+	if len(matches) != int(*profile.Count) {
 		return nil, fmt.Errorf("can not capture the internal cluster id with cluster name %s, profile worker name %s, matches: %v", clusterName, *profile.Name, matches)
 	}
 	return &matches[2], nil


### PR DESCRIPTION
This commit addresses an issue where the internal id parser expects exactly 3 worker profiles.  If node count is not set to 3, this will fail.